### PR TITLE
Decorating the student_view to add mobile app compatibility

### DIFF
--- a/done/done.py
+++ b/done/done.py
@@ -54,6 +54,10 @@ class DoneXBlock(XBlock):
 
         return {'state': self.done}
 
+    # Decorate the view in order to support multiple devices e.g. mobile
+    # See: https://openedx.atlassian.net/wiki/display/MA/Course+Blocks+API
+    # section 'View @supports(multi_device) decorator'
+    @XBlock.supports('multi_device')
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """
         The primary view of the DoneXBlock, shown to students


### PR DESCRIPTION
Adding the `@XBlock.supports("multi_device")` decorator to the `student_view` solves the visibility issues I had on the mobile app (see screenshot below).
I tested this on several xblocks (using _devstack: eucaliptus.3 - edxapp 2.7.5_) and it didn't create any visible problem. 
See: https://openedx.atlassian.net/wiki/display/MA/Course+Blocks+API#CourseBlocksAPI-BlockRendering:Web,Responsive,andNative as a reference. 


![screenshot_2017-01-17-11-25-03_org edx mobile](https://cloud.githubusercontent.com/assets/25111463/22079414/9f530392-dd70-11e6-8a54-8ab1c6457ba8.png)

@stvstnfrd @caesar2164 